### PR TITLE
fix: handle null merged_by in notify_merged Slack message

### DIFF
--- a/.github/workflows/slack-pr-notification-reusable.yml
+++ b/.github/workflows/slack-pr-notification-reusable.yml
@@ -345,10 +345,20 @@ jobs:
           echo "ts=$TS" >> "$GITHUB_OUTPUT"
           echo "found=true" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve merged_by with fallback
+        id: resolve_merged_by
+        run: |
+          MERGED_BY="${{ github.event.pull_request.merged_by.login }}"
+          if [ -z "$MERGED_BY" ] || [ "$MERGED_BY" = "null" ]; then
+            MERGED_BY="API/automation"
+          fi
+          echo "login=$MERGED_BY" >> "$GITHUB_OUTPUT"
+
       - name: Update Slack message
         if: steps.find_ts.outputs.found == 'true'
         run: |
           CHANNEL="${{ inputs.slack_channel_id }}"
+          MERGED_BY="${{ steps.resolve_merged_by.outputs.login }}"
           curl -s -X POST \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
             -H "Content-Type: application/json" \
@@ -356,7 +366,7 @@ jobs:
               --arg channel "$CHANNEL" \
               --arg ts "${{ steps.find_ts.outputs.ts }}" \
               --arg author "${{ github.event.pull_request.user.login }}" \
-              --arg merged_by "${{ github.event.pull_request.merged_by.login }}" \
+              --arg merged_by "$MERGED_BY" \
               --arg title "${{ github.event.pull_request.title }}" \
               --arg branch "${{ github.event.pull_request.head.ref }}" \
               --arg url "${{ github.event.pull_request.html_url }}" \


### PR DESCRIPTION
## Summary

- Fixes the edge case where `merged_by` is `null` when a PR is merged via API or automation (e.g., squash merge via GitHub API)
- Adds a "Resolve merged_by with fallback" step that checks if `merged_by.login` is empty or `"null"`, and falls back to `"API/automation"`
- The resolved value is passed via step output to the Slack payload, so the message never displays "null" as the merger

Closes #5

## Test plan

- [ ] Merge a PR normally via the GitHub UI and verify `merged_by` shows the correct user
- [ ] If possible, merge a PR via the GitHub API (e.g., `gh pr merge --squash`) and verify the Slack message shows "API/automation" instead of "null"
- [ ] Verify the Slack message structure remains intact (color, fields, link)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small workflow-only change that affects Slack message text formatting and adds a safe fallback for missing GitHub event data.
> 
> **Overview**
> Fixes the merged PR Slack update in `.github/workflows/slack-pr-notification-reusable.yml` to avoid displaying `null` for `merged_by`.
> 
> Adds a `Resolve merged_by with fallback` step that derives `merged_by.login` and falls back to `API/automation`, then passes the resolved value into the Slack `chat.update` payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5ecabc824916701558b9521ede7416548ae5b24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->